### PR TITLE
Correct carrier formula in FM files

### DIFF
--- a/fm.py
+++ b/fm.py
@@ -10,7 +10,7 @@ f_m = 220.0
 k = 50.0
 
 tis = np.arange(duration_s * f_s)
-carrier = 2 * np.pi * tis * f_c / tis
+carrier = 2 * np.pi * tis * f_c / f_s
 modulator = k * np.sin(2 * np.pi * tis * f_m / f_s)
 waveform = np.cos(carrier + modulator)
 

--- a/frequency_modulation.ipynb
+++ b/frequency_modulation.ipynb
@@ -147,21 +147,10 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/alicia/anaconda3/lib/python3.6/site-packages/ipykernel_launcher.py:2: RuntimeWarning: divide by zero encountered in true_divide\n",
-      "  \n",
-      "/Users/alicia/anaconda3/lib/python3.6/site-packages/ipykernel_launcher.py:2: RuntimeWarning: invalid value encountered in true_divide\n",
-      "  \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "tis = np.arange(duration_s * f_s)\n",
-    "carrier = 2 * np.pi * tis * f_c / tis\n",
+    "carrier = 2 * np.pi * tis * f_c / f_s\n",
     "modulator = k * np.sin(2 * np.pi * tis * f_m / f_s)\n",
     "waveform = np.cos(carrier + modulator)"
    ]
@@ -170,7 +159,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Write the syntheseized file.\n",
+    "Write the synthesized file.\n",
     "\n",
     "+ `waveform_quiet`: An attenuated waveform that has reasonable volume."
    ]


### PR DESCRIPTION
Great repo! I noticed one small problem: In frequency_modulation.ipynb and fm.py, the carrier formula divides by the sample _numbers_, rather than the sample _rate_. The modulator formula is correct. Fixing this has the added benefit of removing the divide by zero runtime warning.

Also, I corrected one small typo.